### PR TITLE
Remove minimal dead zone at navigation bar (fix Nexus 4)

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/DeadZone.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/DeadZone.java
@@ -90,7 +90,7 @@ public class DeadZone extends View {
             return 0;
         long dt = (now - mLastPokeTime);
         if (dt > mHold + mDecay)
-            return mSizeMin;
+            return 0;
         if (dt < mHold)
             return mSizeMax;
         return (int) lerp(mSizeMax, mSizeMin, (float) (dt - mHold) / mDecay);


### PR DESCRIPTION
CHECK this post: https://plus.google.com/+EduardoVazdeMello/posts/FFcFpXjuN4u

Some Nexus 4 devices have severe hardware issue when bottom touches
floors to 16px and resides in deadzone forever and phone is unusable.

Issue: /a/41219
Change-Id: I1a1543745d51f5df7588d3cc2e54bf537113ffd2
Signed-off-by: Chet Kener <Cl3Kener@gmail.com>